### PR TITLE
Fixes Incompatible Iteration Setter

### DIFF
--- a/src/IterationAwareTrait.php
+++ b/src/IterationAwareTrait.php
@@ -36,13 +36,9 @@ trait IterationAwareTrait
      * @since [*next-version*]
      *
      * @param IterationInterface|null $iteration The iteration instance.
-     *
-     * @return $this
      */
     protected function _setIteration(IterationInterface $iteration = null)
     {
         $this->iteration = $iteration;
-
-        return $this;
     }
 }

--- a/src/IteratorTrait.php
+++ b/src/IteratorTrait.php
@@ -108,5 +108,5 @@ trait IteratorTrait
      *
      * @param IterationInterface|null $iteration The iteration to set.
      */
-    abstract protected function _setIteration($iteration);
+    abstract protected function _setIteration(IterationInterface $iteration = null);
 }


### PR DESCRIPTION
Fixes the incompatibility between [`IteratorTrait::_setIteration()`](https://github.com/Dhii/iterator-abstract/blob/develop/src/IteratorTrait.php#L111) and [`IterationAwareTrait::_setIteration()`](https://github.com/Dhii/iterator-abstract/blob/develop/src/IterationAwareTrait.php#L42).